### PR TITLE
feat: add browser publish editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Retypeset is a static blog theme based on the [Astro](https://astro.build/) fram
 - Optimized typography
 - Responsive design
 - Comment system
+- In-browser editor for publishing articles at `/publish`
 
 ## Performance
 

--- a/src/pages/api/publish.ts
+++ b/src/pages/api/publish.ts
@@ -1,0 +1,69 @@
+import type { APIRoute } from 'astro'
+import { access, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import process from 'node:process'
+
+export const POST: APIRoute = async ({ request }) => {
+  const body = await request.json() as any
+  const title: string = body.title || ''
+  const content: string = body.content || ''
+  const tags: string = body.tags || ''
+
+  if (!title || !content) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Missing title or content' }),
+      { status: 400 },
+    )
+  }
+
+  const slug = slugify(title)
+  const date = new Date().toISOString().slice(0, 10)
+  const tagsArr = tags
+    .split(',')
+    .map((t: string) => t.trim())
+    .filter((t: string) => t.length > 0)
+
+  const frontmatter = [
+    '---',
+    `title: ${title}`,
+    `published: ${date}`,
+    `description: ''`,
+    `updated: ''`,
+    'tags:',
+    ...tagsArr.map((t: string) => `  - ${t}`),
+    'draft: false',
+    'pin: 0',
+    'toc: true',
+    `lang: ''`,
+    `abbrlink: ''`,
+    '---',
+    '',
+  ].join('\n')
+
+  const filePath = join(process.cwd(), 'src', 'content', 'posts', `${slug}.md`)
+
+  try {
+    await access(filePath)
+    return new Response(
+      JSON.stringify({ success: false, error: 'Post already exists' }),
+      { status: 409 },
+    )
+  }
+  catch {
+    // file does not exist
+  }
+
+  await writeFile(filePath, `${frontmatter}${content}\n`, 'utf8')
+
+  return new Response(
+    JSON.stringify({ success: true, slug }),
+    { status: 200 },
+  )
+}
+
+function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '')
+}

--- a/src/pages/publish.astro
+++ b/src/pages/publish.astro
@@ -1,0 +1,60 @@
+---
+import Layout from '@/layouts/Layout.astro'
+---
+
+<Layout postTitle="Publish">
+  <div class="space-y-4">
+    <input id="title" type="text" placeholder="Title" class="w-full border p-2" />
+    <input id="tags" type="text" placeholder="Tags (comma separated)" class="w-full border p-2" />
+    <div class="border p-2">
+      <div id="toolbar" class="mb-2 space-x-2">
+        <button data-command="bold" class="px-2 py-1 border">Bold</button>
+        <button data-command="italic" class="px-2 py-1 border">Italic</button>
+        <button data-command="formatBlock" data-value="h2" class="px-2 py-1 border">H2</button>
+        <button data-command="insertUnorderedList" class="px-2 py-1 border">Bullet</button>
+      </div>
+      <div id="editor" contenteditable="true" class="min-h-80 outline-none"></div>
+    </div>
+    <button id="publish" class="border px-4 py-2">Publish</button>
+  </div>
+
+  <script>
+    const toolbar = document.getElementById('toolbar')
+    const titleInput = document.getElementById('title')
+    const tagsInput = document.getElementById('tags')
+    const editor = document.getElementById('editor')
+    const publishBtn = document.getElementById('publish')
+
+    toolbar?.addEventListener('click', (e) => {
+      const target = e.target
+      if (!(target instanceof HTMLElement))
+        return
+      const cmd = target.dataset.command
+      if (!cmd)
+        return
+      const value = target.dataset.value || null
+      document.execCommand(cmd, false, value)
+    })
+
+    publishBtn?.addEventListener('click', async () => {
+      const title = titleInput?.value || ''
+      const tags = tagsInput?.value || ''
+      const content = editor?.innerHTML || ''
+      const res = await fetch('/api/publish', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, tags, content }),
+      })
+      const data = await res.json()
+      if (data.success) {
+        // eslint-disable-next-line no-alert
+        alert(`Article published at ${data.slug}`)
+      }
+      else {
+        // eslint-disable-next-line no-alert
+        alert(data.error || 'Failed to publish')
+      }
+    })
+  </script>
+</Layout>
+


### PR DESCRIPTION
## Summary
- add /publish page with in-browser editor for writing posts
- add API route to save editor content as markdown files
- document new publish page in README

## Testing
- `pnpm lint` *(fails: 3832 errors in existing files)*
- `pnpm eslint src/pages/api/publish.ts src/pages/publish.astro README.md`

------
https://chatgpt.com/codex/tasks/task_e_689aac6dc6348333aad8b836aac92c1a